### PR TITLE
Fix service

### DIFF
--- a/sauron/service.py
+++ b/sauron/service.py
@@ -127,7 +127,11 @@ def get_payment(cleos: CLEOS, producer_name: str):
     return payment
 
 
-def get_producer_status(cleos: CLEOS, producer_name: str, missed_bpr_cache: int):
+def get_producer_status(
+        cleos: CLEOS,
+        producer_name: str,
+        missed_bpr_cache: int
+):
     producer_status = cleos.get_table(
         account='eosio',
         scope='eosio',
@@ -140,7 +144,7 @@ def get_producer_status(cleos: CLEOS, producer_name: str, missed_bpr_cache: int)
     if int(float(producer_status[0].get('total_votes'))) > 0:
         total_votes =  int(float(producer_status[0].get('total_votes'))) / 10000
 
-    message = BlockProducer(**{
+    bp_status = BlockProducer(**{
         'owner': producer_status[0].get('owner'),
         'is_active': producer_status[0].get('is_active'),
         'total_votes': total_votes,
@@ -150,12 +154,14 @@ def get_producer_status(cleos: CLEOS, producer_name: str, missed_bpr_cache: int)
         'unpaid_blocks': int(producer_status[0].get('unpaid_blocks')),
         'payment': get_payment(cleos, producer_name),
     })
-    if int(message.missed_blocks_per_rotation) > missed_bpr_cache:
-        missed_bpr_cache = message.missed_blocks_per_rotation
-        message.alert = True
-    elif int(message.missed_blocks_per_rotation) == 0 and missed_bpr_cache > 0:
+
+    if int(bp_status.missed_blocks_per_rotation) > missed_bpr_cache:
+        missed_bpr_cache = bp_status.missed_blocks_per_rotation
+        bp_status.alert = True
+    elif int(bp_status.missed_blocks_per_rotation) == 0 and missed_bpr_cache > 0:
         missed_bpr_cache = 0
-    return message, missed_bpr_cache
+
+    return bp_status, missed_bpr_cache
 
 
 def get_abi(cleos: CLEOS, abi_path: str):

--- a/sauron/service.py
+++ b/sauron/service.py
@@ -252,6 +252,11 @@ async def get_all_producers(url: str):
     return producers
 
 
+async def get_producers_list(url: str) -> list[str]:
+    producers = await get_all_producers(url)
+    return [ producer['owner'] for producer in producers ]
+
+
 def get_neighbors(producers: list, producer_name: str):
     for index in range(1, len(producers)):
         if producers[index].get('owner') == producer_name:

--- a/sauron/telegram.py
+++ b/sauron/telegram.py
@@ -44,12 +44,18 @@ def launch_telegram(filename):
                     global missed_bpr_cache
                     global system_status_cache
                     system_status_cache.system = await get_system_info()
-                    response, missed_bpr_cache = await build_producer_status_message(
+                    bp_status, missed_bpr_cache = get_producer_status(
+                        cleos,
+                        config.producer_name,
+                        missed_bpr_cache
+                    )
+
+                    response = await build_producer_status_message(
                         cleos,
                         ntp_client,
+                        bp_status,
                         system_status_cache,
                         config,
-                        missed_bpr_cache
                     )
                     await bot.send_message(config.chat_id, response, parse_mode='HTML')
                 except Exception as e:
@@ -146,12 +152,19 @@ def launch_telegram(filename):
             global system_status_cache
             global missed_bpr_cache
             system_status_cache.system = await get_system_info()
+            bp_status, missed_bpr_cache = get_producer_status(
+                cleos,
+                config.producer_name,
+                missed_bpr_cache
+            )
+
             response, missed_bpr_cache = await build_producer_status_message(
                 cleos,
                 ntp_client,
+                bp_status,
                 system_status_cache,
                 config,
-                missed_bpr_cache)
+            )
             await bot.reply_to(message=message, text=response, parse_mode='HTML')
 
 

--- a/sauron/telegram.py
+++ b/sauron/telegram.py
@@ -142,8 +142,8 @@ def launch_telegram(filename):
 
         @bot.message_handler(commands=['schedule'])
         async def request_producers_schedule(message):
-            producers = await get_all_producers(config.node_url)
-            schedule = get_schedule_message([ producer['owner'] for producer in producers ], config.producer_name)
+            producers = await get_producers_list(config.node_url)
+            schedule = get_schedule_message(producers, config.producer_name)
             await bot.reply_to(message=message, text=schedule, parse_mode='HTML')
 
 

--- a/sauron/utils.py
+++ b/sauron/utils.py
@@ -14,9 +14,9 @@ rocket_emoji = f"<tg-emoji emoji-id='128640'>🚀</tg-emoji>"
 async def build_producer_status_message(
         cleos: CLEOS,
         ntp_client: NTPClient,
+        bp_status: tuple[BlockProducer, int],
         cache_data: Cache,
-        config: dict,
-        missed_bpr_cache: int
+        config: Config,
     ):
 
     sys_health_check = await health_check(cache_data)
@@ -29,7 +29,6 @@ async def build_producer_status_message(
     disk_usage = system_stats.disk_usage.percent
     nodeos_status = system_stats.nodeos_status
 
-    bp_status, new_missed_bpr_cache = get_producer_status(cleos, config.producer_name, missed_bpr_cache)
     total_votes = formatting(bp_status.total_votes)
     lifetime_produced_blocks = formatting(bp_status.lifetime_produced_blocks)
     lifetime_missed_blocks = formatting(bp_status.lifetime_missed_blocks)
@@ -91,9 +90,9 @@ async def build_producer_status_message(
 
     if clock_offset != 'Synced' or bp_status.alert or sys_health_check.alert:
         response += build_tags(config.users_alerted)
-        return response, new_missed_bpr_cache
+        return response
     response += f"\n{green_check_mark_emoji}"
-    return response, new_missed_bpr_cache
+    return response
 
 
 def build_help_message():


### PR DESCRIPTION
 - Build_message minor refactor: the `get_producer_status()` is separate from the
`build_producer_status_message()`,so the `bp_status` can be set prior
`build_producer_status_message()`.

- Move the logic to service layer for getting the bp producer list